### PR TITLE
Fix Span == operator for Swift 6.3

### DIFF
--- a/Sources/MiddlewareRum/OpenTelemetry/OpenTelemetryApi/Trace/Span.swift
+++ b/Sources/MiddlewareRum/OpenTelemetry/OpenTelemetryApi/Trace/Span.swift
@@ -73,10 +73,10 @@ public extension Span {
     func hash(into hasher: inout Hasher) {
         hasher.combine(context.spanId)
     }
+}
 
-    static func == (lhs: Span, rhs: Span) -> Bool {
-        return lhs.context.spanId == rhs.context.spanId
-    }
+public func == (lhs: Span, rhs: Span) -> Bool {
+    return lhs.context.spanId == rhs.context.spanId
 }
 
 public extension Span {


### PR DESCRIPTION
Long standing issue for iOS - changed (request to change) - in Span.swift:
public extension Span {
    func hash(into hasher: inout Hasher) {
        hasher.combine(context.spanId)
    }
    static func == (lhs: Span, rhs: Span) -> Bool {
        return lhs.context.spanId == rhs.context.spanId
    }
}

to 

public extension Span {
    func hash(into hasher: inout Hasher) {
        hasher.combine(context.spanId)
    }
}

public func == (lhs: Span, rhs: Span) -> Bool {
    return lhs.context.spanId == rhs.context.spanId
}